### PR TITLE
[Add] Corona help에 sort key 정보를 추가했습니다.

### DIFF
--- a/utils/cli.js
+++ b/utils/cli.js
@@ -30,6 +30,16 @@ module.exports = meow(
 	  ${green(`corona`)} ${yellow(`--sort`)} ${cyan(`cases-today`)}	Print ${yellow(`sorted`)} data by ${cyan(`cases-today`)}
 	  ${green(`corona`)} ${yellow(`-s`)} ${cyan(`critical`)}		Print ${yellow(`sorted`)} data by ${cyan(`critical`)}
 
+	Sort Key
+	  ${yellow(`Country`)}: Name of the country
+	  ${yellow(`Cases`)}: Total number of cases in a country
+	  ${yellow(`Cases (today)`)}: Cases in 24 hours GMT/UTC
+	  ${yellow(`Deaths`)}: Total number of deaths in a country
+	  ${yellow(`Deaths (today)`)}: Deaths in 24 hours GMT/UTC
+	  ${yellow(`Recovered`)}: Total number of recovered patients
+	  ${yellow(`Active`)}: Total number of active patients
+	  ${yellow(`Critical`)}: Total number of critical patients
+
 	❯ You can also run command + option at once:
 	  ${green(`corona`)} ${cyan(`china`)} ${yellow(`-x`)} ${yellow(`-s cases`)}
 `,

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -39,6 +39,7 @@ module.exports = meow(
 	  ${yellow(`Recovered`)}: Total number of recovered patients
 	  ${yellow(`Active`)}: Total number of active patients
 	  ${yellow(`Critical`)}: Total number of critical patients
+	  ${yellow(`Per Million`)}: Affected patients per million
 
 	❯ You can also run command + option at once:
 	  ${green(`corona`)} ${cyan(`china`)} ${yellow(`-x`)} ${yellow(`-s cases`)}


### PR DESCRIPTION
기존 Corona help에서는 sort를 어떻게 하는지는 나와있지만, 어떤 data로 sort할 수 있는지가 나오지 않는다는 문제가 있었습니다.
설명을 추가해 해결했습니다.