### PR TITLE
sort data 추출기능 입력의 간편화

### DIFF
--- a/utils/table.js
+++ b/utils/table.js
@@ -70,19 +70,31 @@ module.exports = {
 	},
 	sortingKeys: {
 		country: 'country',
+		ca: 'cases' ,
 		cases: 'cases',
 		'cases-today': 'todayCases',
+		'ca-t':'todayCases',
 		deaths: 'deaths',
+		d: 'deaths',
 		'deaths-today': 'todayDeaths',
+		'd-t': 'todayDeaths',
 		recovered: 'recovered',
+		r: 'recovered',
+		a: 'active',
 		active: 'active',
 		critical: 'critical',
-		'per-million': 'casesPerOneMillion'
+		c: 'critical',
+		'per-million': 'casesPerOneMillion',
+		'p-m': 'casesPerOneMillion',
+		
+		
 	},
 	sortingStateKeys: {
 		state: 'state',
 		cases: 'cases',
+		ca: 'cases',
 		'cases-today': 'todayCases',
+		d: 'deaths',
 		deaths: 'deaths',
 		'deaths-today': 'todayDeaths',
 		active: 'active'


### PR DESCRIPTION
cases ->ca
cases-today -> ca-t
deaths -> d
deaths-today -> d-t
recovered -> r
active -> a
critical -> c
per-million -> p-m
위와 같이 입력하여도 데이터를 출력하게끔 기능을 개선시켜 보았습니다