### PR TITLE
[add] 위험 국가 리스트 출력 옵션 - 기능 추가

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const getBar = require('./utils/getBar.js');
 const getWorldwide = require('./utils/getWorldwide.js');
 const getCountries = require('./utils/getCountries.js');
 const getContinents = require('./utils/getContinents.js');
+const getDangerCountry = require('./utils/getDangerCountry.js');
 
 const {
 	style,
@@ -43,7 +44,9 @@ const bar = cli.flags.bar;
 const minimal = cli.flags.minimal;
 const json = cli.flags.json;
 const continent = cli.flags.continent;
-const options = { sortBy, limit, reverse, minimal, chart, log, json, bar, continent };
+const danger = cli.flags.danger;
+
+const options = { sortBy, limit, reverse, minimal, chart, log, json, bar, continent, danger };
 
 (async () => {
 	// Init.
@@ -71,6 +74,7 @@ const options = { sortBy, limit, reverse, minimal, chart, log, json, bar, contin
 	await getCountryChart(spinner, countryList[0], options);
 	await getBar(spinner, countryList[0], states, options);
 	await getContinents(spinner, output, states, countryList[0], options);
+	await getDangerCountry(spinner, output, states, countryList[0], options);
 
 	theEnd(lastUpdated, states, minimal || json);
 })();

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -21,6 +21,7 @@ module.exports = meow(
 	  ${yellow(`-m`)}, ${yellow(`--minimal`)}   Minimalistic CLI output
 	  ${yellow(`-j`)}, ${yellow(`--json`)}      Output JSON only data
 	  ${yellow(`--continent`)}     Print continental data
+	  ${yellow(`--danger`)}     Print dangerous countries
 
 	Examples
 	  ${green(`corona`)} ${cyan(`china`)}		Print data of ${cyan(`china`)}
@@ -99,6 +100,10 @@ module.exports = meow(
 				type: 'boolean',
 				default: false
 				// alias: 'b'
+			},
+			danger: {
+				type: 'boolean',
+				default: false
 			}
 		}
 	}

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -20,7 +20,7 @@ module.exports = meow(
 	  ${yellow(`-x`)}, ${yellow(`--xcolor`)}    Single colored output
 	  ${yellow(`-m`)}, ${yellow(`--minimal`)}   Minimalistic CLI output
 	  ${yellow(`-j`)}, ${yellow(`--json`)}      Output JSON only data
-	  ${yellow(`--continent`)}     Print chart for a country
+	  ${yellow(`--continent`)}     Print continental data
 
 	Examples
 	  ${green(`corona`)} ${cyan(`china`)}		Print data of ${cyan(`china`)}

--- a/utils/getCountries.js
+++ b/utils/getCountries.js
@@ -12,9 +12,9 @@ module.exports = async (
 	output,
 	states,
 	countryName,
-	{ sortBy, limit, reverse, bar, json, continent }
+	{ sortBy, limit, reverse, bar, json, continent, danger }
 ) => {
-	if (!countryName && !states && !bar && !continent) {
+	if (!countryName && !states && !bar && !continent && !danger) {
 		sortValidation(sortBy, spinner);
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/v2/countries`)

--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -7,7 +7,7 @@ const transformName = require('./transformName.js');
 const createCsvWriter = require('csv-writer').createObjectCsvWriter;
 
 module.exports = async (spinner, table, states, countryList, options) => {
-	if (countryList && !states && !options.chart && !options.continent) {
+	if (countryList && !states && !options.chart && !options.continent && !options.danger) {
 		for(let i=0;i<countryList.length;++i){
 			countryList[i] = await transformName(countryList[i]);
 			const [err, response] = await to(

--- a/utils/getDangerCountry.js
+++ b/utils/getDangerCountry.js
@@ -1,0 +1,18 @@
+const axios = require('axios');
+const { cyan, dim } = require('chalk');
+const numberFormat = require('./numberFormat');
+const { sortingKeys } = require('./table.js');
+const to = require('await-to-js').default;
+const handleError = require('cli-handle-error');
+const orderBy = require('lodash.orderby');
+const sortValidation = require('./sortValidation.js');
+
+module.exports = async (
+	spinner,
+	output,
+	states,
+	countryName,
+	{ sortBy, limit, reverse, bar, json, continent }
+) => {
+    
+};

--- a/utils/getDangerCountry.js
+++ b/utils/getDangerCountry.js
@@ -12,7 +12,67 @@ module.exports = async (
 	output,
 	states,
 	countryName,
-	{ sortBy, limit, reverse, bar, json, continent }
+	{ sortBy, limit, reverse, bar, json, continent, danger }
 ) => {
-    
+	if (!countryName && !states && !bar && !continent && danger) {
+		sortValidation(sortBy, spinner);
+		const [err, response] = await to(
+			axios.get(`https://corona.lmao.ninja/v2/countries`)
+		);
+		handleError(`API is down, try again later.`, err, false);
+		let allCountries = response.data;
+
+		// Format.
+		const format = numberFormat(json);
+
+		// Sort & reverse.
+		const direction = reverse ? 'asc' : 'desc';
+		allCountries = orderBy(
+			allCountries,
+			[sortingKeys[sortBy]],
+			[direction]
+		);
+
+        //get worldwide
+        const [err2, response2] = await to(
+            axios.get(`https://corona.lmao.ninja/v2/all`)
+        );
+        handleError(`API is down, try again later.`, err2, false);
+
+        let allData = response2.data;
+        let worldper = allData.casesPerOneMillion;
+        let realCount = 0;
+
+		// Limit.
+		allCountries = allCountries.slice(0, limit);
+
+		// Push selected data.
+		allCountries.map((oneCountry, count) => {
+
+            if (oneCountry.casesPerOneMillion > worldper * 3){
+                realCount++;
+                output.push([
+                    realCount,
+                    oneCountry.country,
+                    format(oneCountry.cases),
+                    format(oneCountry.todayCases),
+                    format(oneCountry.deaths),
+                    format(oneCountry.todayDeaths),
+                    format(oneCountry.recovered),
+                    format(oneCountry.active),
+                    format(oneCountry.critical),
+                    format(oneCountry.casesPerOneMillion)
+                ]);
+            }
+		});
+
+
+		spinner.stopAndPersist();
+		const isRev = reverse ? `${dim(` & `)}${cyan(`Order`)}: reversed` : ``;
+		if (!json) {
+            spinner.info(`${cyan(`About Dangerous Country`)}`);
+		}
+		console.log(output.toString());
+	}
+
 };

--- a/utils/getStates.js
+++ b/utils/getStates.js
@@ -12,9 +12,9 @@ module.exports = async (
 	spinner,
 	output,
 	states,
-	{ sortBy, limit, reverse, json, bar, continent }
+	{ sortBy, limit, reverse, json, bar, continent, danger}
 ) => {
-	if (states && !bar && !continent) {
+	if (states && !bar && !continent && !danger) {
 		sortStatesValidation(sortBy, spinner);
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/v2/states`)


### PR DESCRIPTION
`--danger` 옵션을 통해 위험 국가를 출력해주는 기능을 추가하였습니다.
해당 옵션의 간단한 설명을 cli.js 에 추가하였으며, getDangerCountry.js 파일을 통해 새로운 기능을 분리하였습니다.
위험 국가의 지표에 대해서는 관련 이슈에 자세히 기록되어있습니다.

만약, 속도개선 등을 통해 지표의 최신성이나 정확성을 상승시킬 수 있는 방법을 찾는다면 해당 부분을 다시 개발하도록 하겠습니다.
![image](https://user-images.githubusercontent.com/37038105/100535871-0a8a0a00-3260-11eb-91e5-fe931b7a7224.png)

ps1. 위의 사진에서 0 으로 표기되는 부분은 아직 당일 데이터가 수집되지 않았기 때문입니다.
ps2. 이전에 continent 옵션 관련 설명에 살짝 부족한 점이 보여 약간 수정하였습니다.
