### PR TITLE
[add] 코로나 뉴스 웹 크롤링 기능

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const getWorldwide = require('./utils/getWorldwide.js');
 const getCountries = require('./utils/getCountries.js');
 const getContinents = require('./utils/getContinents.js');
 const getDangerCountry = require('./utils/getDangerCountry.js');
+const getnews = require('./utils/news.js');
 
 const {
 	style,
@@ -46,7 +47,9 @@ const json = cli.flags.json;
 const continent = cli.flags.continent;
 const danger = cli.flags.danger;
 const csv = cli.flags.csv;
-const options = { sortBy, limit, reverse, minimal, chart, log, json, bar, continent, danger, csv };
+const news = cli.flags.news;
+
+const options = { sortBy, limit, reverse, minimal, chart, log, json, bar, continent, danger, csv, news };
 
 (async () => {
 	// Init.
@@ -75,6 +78,7 @@ const options = { sortBy, limit, reverse, minimal, chart, log, json, bar, contin
 	await getBar(spinner, countryList[0], states, options);
 	await getContinents(spinner, output, states, countryList[0], options);
 	await getDangerCountry(spinner, output, states, countryList[0], options);
+	await getnews(spinner,options);
 
 	theEnd(lastUpdated, states, minimal || json);
 })();

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
 		"moment": "^2.24.0",
 		"ora": "^4.0.4",
 		"update-check": "^1.5.4",
-		"update-notifier": "^4.1.0"
+		"update-notifier": "^4.1.0",
+		"cheerio": "^1.0.0-rc.3"
 	},
 	"devDependencies": {
 		"prettier": "^2.0.5"

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -23,6 +23,7 @@ module.exports = meow(
 	  ${yellow(`--continent`)}                  Print continental data
 	  ${yellow(`--danger`)}                     Print dangerous countries
 	  ${yellow(`--csv`)}                        CSV-file export
+	  ${yellow(`--news`)}                       Print corona news
 
 	Examples
 	  ${green(`corona`)} ${cyan(`china`)}		Print data of ${cyan(`china`)}
@@ -110,7 +111,11 @@ module.exports = meow(
 			csv: {
 				type: 'boolean',
 				default: false,
-			}
+			},
+			news: {
+				type: 'boolean',
+				default: false,
+			}			
 		}
 	}
 );

--- a/utils/getCountries.js
+++ b/utils/getCountries.js
@@ -12,9 +12,9 @@ module.exports = async (
 	output,
 	states,
 	countryName,
-	{ sortBy, limit, reverse, bar, json, continent, danger}
+	{ sortBy, limit, reverse, bar, json, continent, danger, news}
 ) => {
-	if (!countryName && !states && !bar && !continent && !danger) {
+	if (!countryName && !states && !bar && !continent && !danger && !news) {
 		sortValidation(sortBy, spinner);
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/v2/countries`)

--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -7,7 +7,7 @@ const transformName = require('./transformName.js');
 const createCsvWriter = require('csv-writer').createObjectCsvWriter;
 
 module.exports = async (spinner, table, states, countryList, options) => {
-	if (countryList && !states && !options.chart && !options.continent && !options.danger) {
+	if (countryList && !states && !options.chart && !options.continent && !options.danger && !options.news) {
 
 		var countries_data = []
 

--- a/utils/getStates.js
+++ b/utils/getStates.js
@@ -12,9 +12,9 @@ module.exports = async (
 	spinner,
 	output,
 	states,
-	{ sortBy, limit, reverse, json, bar, continent, danger, csv}
+	{ sortBy, limit, reverse, json, bar, continent, danger, csv, news}
 ) => {
-	if (states && !bar && !continent && !danger) {
+	if (states && !bar && !continent && !danger && !news) {
 		sortStatesValidation(sortBy, spinner);
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/v2/states`)

--- a/utils/news.js
+++ b/utils/news.js
@@ -1,0 +1,32 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+const log = console.log;
+
+module.exports = async ( spinner, {news} ) => {
+
+    if (news){
+
+      const datas = await axios.get("https://www.bbc.com/news/coronavirus")
+      .then(html => {
+        let ulList = [];
+        const $ = cheerio.load(html.data);
+        const $bodyList = $("div.gs-o-media__body").children("h3.lx-stream-post__header-title.gel-great-primer-bold.qa-post-title.gs-u-mt0.gs-u-mb-")
+    
+        $bodyList.each(function(i, elem) {
+          ulList[i] = {
+            title: $(this).find("span.lx-stream-post__header-text.gs-u-align-middle").text().replace("'",""),
+            url: 'www.bbc.com' + $(this).find('a.qa-heading-link.lx-stream-post__header-link').attr('href')
+          };
+          
+        });
+    
+        const data = ulList.filter(n => n.title);
+        return data;
+      })
+      .then(res => log(res));
+
+    }
+
+    spinner.stopAndPersist();
+
+}


### PR DESCRIPTION
BBC 뉴스 사이트를 기반으로 코로나 관련 뉴스를 크롤링 해오는 기능을 만들었습니다.
해당 기능은 `cheerio` 라는 새로운 모듈을 사용하기에, 테스트 해보실 경우 `npm install` 를 다시 한번 해주실 필요가 있습니다.
실행 화면은 다음과 같습니다.

![image](https://user-images.githubusercontent.com/37038105/100542364-ccefa600-328c-11eb-88b2-d26241963881.png)

저도 웹 크롤링 기능은 처음 사용해 본것이라, 사진에서 알 수 있듯이 아직 개선할 부분이 있습니다.
저도 시간이 되는데로 해당 기능을 개선할 것이지만, 저 말고도 개선에 관심이 있으신 분이 있을 수도 있어서 이렇게 풀리퀘스트와 머지를 요청하게 되었습니다. 언제나 어사인 해주시면 감사하겠습니다.
