### PR TITLE
[change] 위험국가 지표 CDC 보건고지 레벨로 변경

### DIFF
--- a/utils/cli.js
+++ b/utils/cli.js
@@ -20,10 +20,10 @@ module.exports = meow(
 	  ${yellow(`-x`)}, ${yellow(`--xcolor`)}    Single colored output
 	  ${yellow(`-m`)}, ${yellow(`--minimal`)}   Minimalistic CLI output
 	  ${yellow(`-j`)}, ${yellow(`--json`)}      Output JSON only data
-	  ${yellow(`--continent`)}                  Print continental data
-	  ${yellow(`--danger`)}                     Print dangerous countries referring to CDC Health Notice Level
-	  ${yellow(`--csv`)}                        CSV-file export
-	  ${yellow(`--news`)}                       Print corona news
+	  ${yellow(`--continent`)}     Print continental data
+	  ${yellow(`--danger`)}        Print dangerous countries referring to CDC Health Notice Level
+	  ${yellow(`--csv`)}           CSV-file export
+	  ${yellow(`--news`)}          Print corona news
 
 	Examples
 	  ${green(`corona`)} ${cyan(`china`)}		Print data of ${cyan(`china`)}

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -21,7 +21,7 @@ module.exports = meow(
 	  ${yellow(`-m`)}, ${yellow(`--minimal`)}   Minimalistic CLI output
 	  ${yellow(`-j`)}, ${yellow(`--json`)}      Output JSON only data
 	  ${yellow(`--continent`)}                  Print continental data
-	  ${yellow(`--danger`)}                     Print dangerous countries
+	  ${yellow(`--danger`)}                     Print dangerous countries referring to CDC Health Notice Level
 	  ${yellow(`--csv`)}                        CSV-file export
 	  ${yellow(`--news`)}                       Print corona news
 

--- a/utils/getDangerCountry.js
+++ b/utils/getDangerCountry.js
@@ -40,17 +40,60 @@ module.exports = async (
         );
         handleError(`API is down, try again later.`, err2, false);
 
+		//get month_data
+        const [err3, response3] = await to(
+            axios.get(`https://corona.lmao.ninja/v2/historical`)
+        );
+        handleError(`API is down, try again later.`, err3, false);
+		if (response3.status === 404) {
+			spinner.stopAndPersist();
+			console.log(
+				`${red(
+					`${sym.error} Nops. A country does not exist…`
+				)}\n`
+			);
+			process.exit(0);
+		}
+
         let allData = response2.data;
         let worldper = allData.casesPerOneMillion;
         let realCount = 0;
+		let code = 0;
+		let flag = 0;
+		let cdc_flag = 0;
+		let con_pop = 0;
+		let month_case = 0;
 
 		// Limit.
-		allCountries = allCountries.slice(0, limit);
+		allCountries = allCountries.slice(0, Number.MAX_SAFE_INTEGER);
 
 		// Push selected data.
 		allCountries.map((oneCountry, count) => {
 
-            if ((realCount < 20) || (oneCountry.casesPerOneMillion > worldper * 3)){
+			flag = 0;
+			cdc_flag = 0;
+			month_case = 0;
+
+			for(let i = 0;i<271;i++){
+				if (response3.data[i].country == oneCountry.country){
+					let cases = Object.values(response3.data[i].timeline.cases);
+					month_case += cases[cases.length - 1] - cases[0];
+					flag = 1;
+				}
+			}
+
+			if (flag){
+
+				con_pop = oneCountry.cases/oneCountry.casesPerOneMillion * 1000000;
+				con_pop = Math.floor(con_pop);
+				if (month_case/con_pop*100000 > 100){
+					// console.log(oneCountry.country);
+					// console.log(month_case/con_pop*100000);
+					cdc_flag = 1;
+				}
+			}
+
+            if (cdc_flag && realCount<limit){
                 realCount++;
                 output.push([
                     realCount,
@@ -71,7 +114,9 @@ module.exports = async (
 		spinner.stopAndPersist();
 		const isRev = reverse ? `${dim(` & `)}${cyan(`Order`)}: reversed` : ``;
 		if (!json) {
-            spinner.info(`${cyan(`About Dangerous Country`)}`);
+			spinner.info(`${cyan(`About Dangerous Country, referring to CDC's Incidence Rate Ranges for COVID-19 Travel Health Notice Level 4`)}
+  https://www.cdc.gov/coronavirus/2019-ncov/travelers/how-level-is-determined.html`);
+			spinner.info(`${cyan(`The sort order is Per Million for convenience, but the following countries are all Level 4 countries.`)}`);
 		}
 		console.log(output.toString());
 	}

--- a/utils/getDangerCountry.js
+++ b/utils/getDangerCountry.js
@@ -42,7 +42,7 @@ module.exports = async (
 
 		//get month_data
         const [err3, response3] = await to(
-            axios.get(`https://corona.lmao.ninja/v2/historical`)
+            axios.get(`https://corona.lmao.ninja/v2/historical/`)
         );
         handleError(`API is down, try again later.`, err3, false);
 		if (response3.status === 404) {


### PR DESCRIPTION
위험 국가의 지표를 CDC 보건고지 레벨 4로 변경하였습니다.
우선, 지난번에 있었던 시간지연 문제의 경우 
`axios.get(https://corona.lmao.ninja/v2/historical/${oneCountry.country})` 대신
`axios.get(https://corona.lmao.ninja/v2/historical/)` 를 사용하여 해결하였습니다. 
그러나 여전히 타 기능보다 시간이 걸린다는 점은 사실입니다.

현재 대략 80개국 정도가 레벨 4 위험국가로 분류되며, --limit을 통해 갯수를 제한할 수 있습니다.
마지막으로 아쉬운 부분은 정렬의 기준입니다.
corona-cli의 경우 기존 sort key 에 제가 위험 국가 기준으로 설정한 **최근(대락 1달) 100,000명당 누적 신규 사례수** 가 없기에, 
해당 위험도를 기준으로 sort를 하려면 기존 corona cli 표의 구조와 코드를 많이 수정해야합니다.
현재는 편의상 per-million 으로 표를 sort 했습니다. 따라서 해당 부분은 추후 시간이 되면 개선하면 될 것 같습니다.


![image](https://user-images.githubusercontent.com/37038105/100585632-3b863f80-3331-11eb-8924-01e3f2e07c33.png)