### PR TITLE
[UPDATE] getCountry.js의 콘솔 로그 for loop 밖으로 빼고 news를 테이블 삽입

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ const options = { sortBy, limit, reverse, minimal, chart, log, json, bar, contin
 	await getBar(spinner, countryList[0], states, options);
 	await getContinents(spinner, output, states, countryList[0], options);
 	await getDangerCountry(spinner, output, states, countryList[0], options);
-	await getnews(spinner,options);
+	await getnews(spinner, options);
 
 	theEnd(lastUpdated, states, minimal || json);
 })();

--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -49,15 +49,13 @@ module.exports = async (spinner, table, states, countryList, options) => {
 					critical: thisCountry.critical,
 					casesPerOneMillion: thisCountry.casesPerOneMillion
 				}
-			]
+			];
 
 			countries_data.push(data[0]);
 		
-			if(i==countryList.length-1){
-				spinner.stopAndPersist();
-				console.log(table.toString());
-			}
 		}
+		spinner.stopAndPersist();
+		console.log(table.toString());
 
 		if(options.csv){
 			var fs=require('fs');

--- a/utils/news.js
+++ b/utils/news.js
@@ -1,32 +1,42 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
 const log = console.log;
+const chalk = require('chalk');
+const green = chalk.green;
 
-module.exports = async ( spinner, {news} ) => {
+module.exports = async (spinner, { news }) => {
 
-    if (news){
+    if (news) {
 
-      const datas = await axios.get("https://www.bbc.com/news/coronavirus")
-      .then(html => {
-        let ulList = [];
-        const $ = cheerio.load(html.data);
-        const $bodyList = $("div.gs-o-media__body").children("h3.lx-stream-post__header-title.gel-great-primer-bold.qa-post-title.gs-u-mt0.gs-u-mb-")
-    
-        $bodyList.each(function(i, elem) {
-          ulList[i] = {
-            title: $(this).find("span.lx-stream-post__header-text.gs-u-align-middle").text().replace("'",""),
-            url: 'www.bbc.com' + $(this).find('a.qa-heading-link.lx-stream-post__header-link').attr('href')
-          };
-          
-        });
-    
-        const data = ulList.filter(n => n.title);
-        return data;
-      })
-      .then(res => log(res));
+        const datas = await axios.get("https://www.bbc.com/news/coronavirus")
+            .then(html => {
+                let ulList = [];
+                const $ = cheerio.load(html.data);
+                const $bodyList = $("div.gs-o-media__body").children("h3.lx-stream-post__header-title.gel-great-primer-bold.qa-post-title.gs-u-mt0.gs-u-mb-");
+
+                $bodyList.each(function (i, elem) {
+                    ulList[i] = {
+                        title: $(this).find("span.lx-stream-post__header-text.gs-u-align-middle").text().replace("'", ""),
+                        url: 'www.bbc.com' + $(this).find('a.qa-heading-link.lx-stream-post__header-link').attr('href')
+                    };
+
+                });
+
+                const data = ulList.filter(n => n.title);
+
+                const newsTable = require('cli-table3');
+                var table = new newsTable();
+                for (let i = 0; i < data.length; ++i) {
+                    table.push(
+                        [{ rowSpan: 2, content: i + 1, vAlign: 'center' }, data[i].title],
+                        [green(data[i].url)]
+                    );
+                }
+                spinner.stopAndPersist();
+                log(table.toString());
+            });
 
     }
 
-    spinner.stopAndPersist();
 
 }


### PR DESCRIPTION


https://github.com/20-2-SKKU-OSS/2020-2-OSS-2/blob/d1ed5b6d14c75aab337a87ba0b282a8c5cf5308e/utils/getCountry.js#L56-L59
1. getCountry.js의 if문을 for loop 문 밖으로 빼 간결하게 해주었고

![news](https://user-images.githubusercontent.com/61929981/100685319-79ca4000-33bf-11eb-93e9-0390419d3057.png)
2. news.js의 출력 포맷을 **cli-table3**를 사용해 예쁘게 만들어주었습니다.

리뷰 후 머지 부탁드리겠습니다.