### PR TITLE
[add] CDC 위험국가 및 포괄적인 국가 검색 주석 추가

### DIFF
--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -15,6 +15,7 @@ module.exports = async (spinner, table, states, countryList, options) => {
 		var countries_data = []
 
 		for(let i=0;i<countryList.length;++i){
+			//Country name is transformed into standards for a comprehensive search.
 			countryList[i] = await transformName(countryList[i]);
 			const [err, response] = await to(
 				axios.get(`https://corona.lmao.ninja/v2/countries/${countryList[i]}`)

--- a/utils/getDangerCountry.js
+++ b/utils/getDangerCountry.js
@@ -7,6 +7,13 @@ const handleError = require('cli-handle-error');
 const orderBy = require('lodash.orderby');
 const sortValidation = require('./sortValidation.js');
 
+/*
+The indicators of dangerous countries referenced the following:
+
+	Incidence Rate Ranges for COVID-19 Travel Health Notice Levels Destinations, LEVEL 4 VERY HIGH
+	Cases per 100,000 people over past 28 days More than 100
+	link : https://www.cdc.gov/coronavirus/2019-ncov/travelers/how-level-is-determined.html
+*/
 module.exports = async (
 	spinner,
 	output,
@@ -55,6 +62,19 @@ module.exports = async (
 			process.exit(0);
 		}
 
+/*
+How to calculate indicator(Cases per 100,000 people over past 28 days More than 100) in the code
+
+	1. The population of a specific country(con_pop) is calculated using the following formula
+		Country.cases/Country.casesPerOneMillion * 1000000
+		
+	2. The number of new cases in the last 28 days(month_case) is obtained through "corona.lmao.ninja/v2/historical/" as follows
+		cases[Latest date] - cases[Oldest date (28 days ago)]
+
+	3. Cases per 100,000 people over past 28 days More than 100 is calculated as follows
+		The number of new cases(month_case) / The population of country(con_pop) * 100000
+
+*/
         let allData = response2.data;
         let worldper = allData.casesPerOneMillion;
         let realCount = 0;

--- a/utils/transformName.js
+++ b/utils/transformName.js
@@ -1,8 +1,13 @@
 
 module.exports = async (countryName) => {
 
-    //Sources of all country names are referenced at "en.wikipedia.org".
-
+    /*
+        1. Sources of all country names are referenced at "en.wikipedia.org".
+        2. Return value should always be a standardized (default output to corona-cli) country name.
+        The countries currently supported are:
+            S. korea, USA, China, Japan, Russia, United Kingdom, Germany
+    */
+   
     //S. korea
     if(countryName == "korea" || countryName == "Korea" || countryName == "S.Korea" || countryName == "Korea, Republic of" || countryName == "ROK" || 
        countryName == "southkorea" || countryName == "SouthKorea" || countryName == "Hanguk" || countryName == "hanguk"){
@@ -46,6 +51,7 @@ module.exports = async (countryName) => {
         return "Germany";
     }
 
+    //Not applicable to transform.
     else {
         return countryName;
     }


### PR DESCRIPTION
제가 추가한 기능들의 코드를 다시 보던 중 추후 다른 분이 작업을 하실때 모호한 부분이 있을것 같아서 주석을 추가했습니다.
추가한 주석은 다음과 같습니다.

1. transformName() 함수의 기능에 대한 간단한 주석을 getCountry.js 에 추가하였습니다.
2. transformName.js 에 함수의 주의사항과 함수가 지원하는 국가를 추가했습니다.
3. CDC의 위험국가 Level 4 기준의 소개와 출처를 getDangerCountry.js 에 추가하였습니다.
4. Cases per 100,000 people over past 28 days의 변수 사용과 계산법을 단계별로 설명해 놓았습니다.
(ex. 기존 corona-cli에는 없는 국가별 전체 인구수를 구하는 법)

해당 풀리퀘스트는 주석만 추가한 것이며, 해당 기능들이 문제 없이 작동함을 확인하였습니다.
따라서 하루동안 리뷰가 없으면 직접 머지하도록 하겠습니다.